### PR TITLE
fix: haproxy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ more options
       prometheus_exporter_name: "haproxy_exporter"
       prometheus_enable_exporter_config_flags: true
       prometheus_exporter_config_flags:
-       'haproxy.scrape-uri': 'unix:/run/haproxy/admin.sock'
+       '--haproxy.scrape-uri': 'unix:/run/haproxy/admin.sock'
 ```
 
 ### HAproxy configuration 


### PR DESCRIPTION
The haproxy example doesn't work as it needs `--`  in front of the option

```
prometheus_haproxy_exporter[9986]: haproxy_exporter: error: unexpected haproxy.scrape-uri=unix:/run/haproxy/admin.sock, try --help
```