### PR TITLE
Make arch configurable, default to linux-amd64

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 prometheus_exporter_version: 0.15.1
+# specify arch, linux-amd64, darwin-amd64, linux-armv7, etc.
+prometheus_exporter_arch: linux-amd64
 # prometheus_exporter_name: "node_exporter"
 prometheus_website_name: github.com
 prometheus_github_username: prometheus

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 
-prometheus_exporter_release_name: "{{prometheus_exporter_name}}-{{ prometheus_exporter_version }}.linux-amd64"
+prometheus_exporter_release_name: "{{prometheus_exporter_name}}-{{ prometheus_exporter_version }}.{{ prometheus_exporter_arch }}"
 url: "https://{{prometheus_website_name}}/{{prometheus_github_username}}/{{prometheus_exporter_name}}/releases/download/v{{ prometheus_exporter_version }}/{{ prometheus_exporter_release_name }}.tar.gz"


### PR DESCRIPTION
Enable role to be used to install Prometheus Node Exporter on other arch, such as darwin-amd64, linux-armv7, etc. 

Molecule test suite run ok.
```
    PLAY RECAP *********************************************************************
    blackbox_exporter          : ok=6    changed=4    unreachable=0    failed=0
    haproxy_exporter           : ok=6    changed=4    unreachable=0    failed=0
    mysql_exporter             : ok=6    changed=4    unreachable=0    failed=0
    node_exporter              : ok=6    changed=4    unreachable=0    failed=0
    postgres_exporter          : ok=6    changed=4    unreachable=0    failed=0


Verifier completed successfully.
```

Install to linux-amd64 host (default) and Raspberry Pi. 
```
$ cat env-dev/hosts | awk '/prometheus/,0' | head -n3
[prometheus]
pi1 prometheus_exporter_arch=linux-armv7
kvmhost1
```

Verify Node Exporter on Linux AMD64 host. 
```
$ curl kvmhost1:9100/metrics | head -n10
# HELP go_gc_duration_seconds A summary of the GC invocation durations.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0
go_gc_duration_seconds{quantile="0.25"} 0
go_gc_duration_seconds{quantile="0.5"} 0
go_gc_duration_seconds{quantile="0.75"} 0
go_gc_duration_seconds{quantile="1"} 0
go_gc_duration_seconds_sum 0
go_gc_duration_seconds_count 0
# HELP go_goroutines Number of goroutines that currently exist.
```

Verify Node Exporter on Raspberry Pi running Raspbian Stretch.
```
$ curl pi1:9100/metrics | head -n10
# HELP go_gc_duration_seconds A summary of the GC invocation durations.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0.000385312
go_gc_duration_seconds{quantile="0.25"} 0.000385312
go_gc_duration_seconds{quantile="0.5"} 0.000385312
go_gc_duration_seconds{quantile="0.75"} 0.000385312
go_gc_duration_seconds{quantile="1"} 0.000385312
go_gc_duration_seconds_sum 0.000385312
go_gc_duration_seconds_count 1
# HELP go_goroutines Number of goroutines that currently exist.
....
$ cat /etc/os-release
PRETTY_NAME="Raspbian GNU/Linux 9 (stretch)"
NAME="Raspbian GNU/Linux"
VERSION_ID="9"
```