### PR TITLE
Change user & group type to be system user & group

### DIFF
--- a/molecule/default/tests/test_default.yml
+++ b/molecule/default/tests/test_default.yml
@@ -6,8 +6,8 @@ service:
 user:
   prometheus:
     exists: true
-    uid: 1000
-    gid: 1000
+    uid: 999
+    gid: 999
     groups:
       - prometheus
     home: /home/prometheus

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 - name: create Prometheus group
-  group: name={{ prometheus_exporters_common_group }}  state=present
+  group:
+    name: "{{ prometheus_exporters_common_group }}"
+    state: present
+    system: yes
 
 - name: create Prometheus user
   user:
@@ -10,6 +13,7 @@
     shell: /sbin/nologin
     comment: "Prometheus User"
     state: present
+    system: yes
 
 - name: mkdir for general cases
   file:
@@ -56,18 +60,6 @@
     path: "{{ exporter_path }}"
     state: directory
     mode: 0755
-
-- name: create Prometheus group
-  group: name={{ prometheus_exporters_common_group }}  state=present
-
-- name: create Prometheus Workign user and group
-  user:
-    name: "{{ prometheus_exporters_common_user }}"
-    group: "{{ prometheus_exporters_common_group }}"
-    createhome: no
-    shell: /sbin/nologin
-    comment: "Prometheus User"
-    state: present
 
 - name: create gz directory "{{ generic_exporter_binary_path }}"
   file:


### PR DESCRIPTION
Per the `useradd --system <user>` method.
```
vagrant@vagrant-test:~$ cat /etc/passwd | grep prometheus
prometheus:x:999:999:Prometheus User:/home/prometheus:/sbin/nologin
```
- Prevents potential display of `prometheus` user to login managers
- Clearly designates system user

Secondly: remove duplicate user & group tasks.