### PR TITLE
fix: download destination for modules

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,7 +75,7 @@
   register: exporter_compressed_download
 
 - name: set up prometheus_exporter_dir_name variable
-  set_fact: prometheus_exporter_dir_name="{{ exporter_compressed_download.dest.split('/')[-1].replace('.tar.gz','') }}"
+  set_fact: prometheus_exporter_dir_name="{{ url.split('/')[-1].replace('.tar.gz','') }}"
 
 - name: unarchive binary tarball
   unarchive:


### PR DESCRIPTION
Hello ! 

Since v1.0.1 the playbook is unable to unarchive module tarball and fail like so: 

```
TASK [ansible-prometheus-exporter : unarchive binary tarball] *********************************************************
fatal: [X.X.X.X]: FAILED! => {"changed": false, "msg": "Source '/opt/prometheus/exporter_gz/node_exporter/node_exporter.tar.gz' does not exist"}
```