### PR TITLE
Security: Make config file unreadable for others

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -121,8 +121,8 @@
     src: etc/sysconfig/default_template.j2
     dest: /etc/sysconfig/{{ prometheus_exporter_name }}
     owner: root
-    group: root
-    mode: 0644
+    group: "{{ prometheus_exporters_common_group }}"
+    mode: 0640
   notify:
     - restart {{prometheus_exporter_name}}
 


### PR DESCRIPTION
Credentials should not be world readable, see DATA_SOURCE_NAME in /etc/sysconfig/mysqld_exporter